### PR TITLE
MYSQL Version Tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
    mysql:
-     image: mysql:latest
+     image: mysql:5.7.22
      container_name: mysql
      restart: always
      volumes:


### PR DESCRIPTION
Currently MYSQL version tag 'latest' downloads version 8.0 which is not supported by faveo.
Switching to version 5.7.22 fixes the issue.
