### PR TITLE
Update Nginx version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:1.11.10
 
 MAINTAINER Himanshu Verma <himanshu@attabot.io>
 


### PR DESCRIPTION
php5 has issues in debian on nginx 12,13,14 so you can't use php5 in those versions without extending the repository to include jessie repos. 

Please use this version of nginx for the image